### PR TITLE
Remove BeautifulSoup's Warning

### DIFF
--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -540,7 +540,7 @@ class MetadataParser(object):
             try:
                 doc = BeautifulSoup(html, "lxml")
             except:
-                doc = BeautifulSoup(html)
+                doc = BeautifulSoup(html, "html.parser")
         else:
             doc = html
 


### PR DESCRIPTION
For everyone who is using a more recent version of BeautifulSoup, not providing the name of the parser throws a warning:

```
/Users/xethorn/Documents/Projects/fllio-api/env/lib/python3.4/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")

  markup_type=markup_type))
```
